### PR TITLE
Added new enum to indicate 'invalid input'

### DIFF
--- a/OnboardService.h
+++ b/OnboardService.h
@@ -29,6 +29,7 @@ typedef std::function<void(const std::string interfaceId, std::string receivedDa
 ///
 enum WifiStatus {
   SUCCESS,
+  INVALID_INPUT,
   AUTH_FAIL,
   UNAVAILABLE,
   FAIL


### PR DESCRIPTION
Added new enum member to indicate that the provided input (SSID, password) is invalid (e.g. larger than the valid length, etc.)